### PR TITLE
update metadata to include GNOME 46 as supported version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "description": "When a workspace switch occurs, this extension ensures the focus is on a window located in the new workspace.\n\nThis extension is essential for a multi-monitor setup using multiple workspaces.",
   "uuid": "fix-focus-on-workspace-switch@hiddn.github.com",
   "shell-version": [
-    "45"
+    "45", "46"
   ],
   "url": "https://github.com/hiddn/fix-focus-on-workspace-switch"
 }


### PR DESCRIPTION
I tested this extension on GNOME 46 and it ran without errors. Therefore v46 should be included as supported.