### PR TITLE
Fix ambiguous indirect export error

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -37,7 +37,7 @@ SOFTWARE.
 
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import GLib from 'gi://GLib';
-import overview from 'resource:///org/gnome/shell/ui/main.js';
+import {overview} from 'resource:///org/gnome/shell/ui/main.js';
 
 
 const __DEBUG__ = false;


### PR DESCRIPTION
Couldn't load the extension, had an error message saying "ambiguous indirect export". This seems to fix it.